### PR TITLE
Fix display issues under high CPU load

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,7 @@ use std::error;
 use std::fmt;
 use std::io;
 use std::result;
+use std::time::Duration;
 use std::slice;
 
 use rppal::gpio::{Gpio, OutputPin};
@@ -250,6 +251,7 @@ impl SerialOutput for BlinktGpio {
                 }
 
                 self.pin_clock.set_high();
+                std::thread::sleep(Duration::from_nanos(10000));
                 self.pin_clock.set_low();
             }
         }


### PR DESCRIPTION
Fixes #5 by introducing a 10,000ns delay between setting the clock signal high and low, which is the same timing used to fix pimoroni/blinkt#62
